### PR TITLE
set AWS RDS storage encrypted to true by default

### DIFF
--- a/src/cnc/flavors/aws/ecs/1/provision/partials/active_and_paused_envs.tf.j2
+++ b/src/cnc/flavors/aws/ecs/1/provision/partials/active_and_paused_envs.tf.j2
@@ -31,6 +31,7 @@ resource "aws_db_instance" "{{ resource.instance_name }}" {
     vpc_security_group_ids = [aws_security_group.{{ env_collection.instance_name }}_db.id]
     skip_final_snapshot = true
     allow_major_version_upgrade = true
+    storage_encrypted = true
 
     {%- if resource.settings.db_name %}
     db_name = "{{ resource.settings.db_name }}"


### PR DESCRIPTION
Set flag to enable RDS storage encryption by default. Currently, encrypting a database _after_ it's created is tedious. As a matter of good data stewardship, it should be enabled by default.


https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html

>StorageEncrypted
    Specifes whether the DB instance is encrypted. By default, it isn't encrypted. For RDS Custom DB instances, either enable this setting or leave it unset. Otherwise, Amazon RDS reports an error. 
This setting doesn't apply to Amazon Aurora DB instances. The encryption for DB instances is managed by the DB cluster. Type: Boolean 
Required: No


> If StorageEncrypted is enabled, and you do not specify a value for the KmsKeyId parameter, then Amazon RDS uses your default KMS key. There is a default KMS key for your AWS account. Your AWS account has a different default KMS key for each AWS Region.
