### PR TITLE
fix missing endif block for jinja gcp/gke/deploy/deploy_functions template

### DIFF
--- a/src/cnc/flavors/gcp/gke/1/deploy/deploy_functions.sh.j2
+++ b/src/cnc/flavors/gcp/gke/1/deploy/deploy_functions.sh.j2
@@ -77,7 +77,6 @@ deploy_{{ service.name }}_tasks () {
 }
 {% endif %}
 
-
 deploy_{{ service.name }}_workers_tasks () {
     create_secrets_{{ service.name }}
 
@@ -89,6 +88,8 @@ deploy_{{ service.name }}_workers_tasks () {
     deploy_{{ service.name }}_tasks
     {% endif %}
 }
+
+{% endif %} # service.is_backend
 
 deploy_{{ service.name }} () {
     gcloud container clusters get-credentials --zone {{ environment.collection.region }} {{ environment.collection.instance_name }}


### PR DESCRIPTION
i think [this change](https://github.com/coherenceplatform/cnc/commit/dbb38bc79953936a0c48e2b5db9c1bc30b1ccfd2#diff-0a35521dd6cb78c5e431dbd0e1319c6594a9fa886aa653df7e695915ceb421ddL59) introduced a bug with rendering a template

```
TemplateSyntaxError: Encountered unknown tag 'endblock'. You probably made a nesting mistake. Jinja is expecting this tag, but currently looking for 'elif' or 'else' or
'endif'. The innermost block that needs to be closed is 'if'.
```