### PR TITLE
Add timestamp to run yml to force new rev

### DIFF
--- a/src/cnc/flavors/gcp/run-lite/1/deploy/run-container.yml.j2
+++ b/src/cnc/flavors/gcp/run-lite/1/deploy/run-container.yml.j2
@@ -33,6 +33,8 @@ spec:
           {{ svc_command }}
       {% endif %}
         env:
+        - name: CNC_DEPLOY_TIMESTAMP
+          value: {{ deployer.current_timestamp }}
         - name: CNC_PROVISIONED
           value: "1"
         {% for variable in service.insecure_environment_items %}

--- a/src/cnc/flavors/gcp/shared/deploy/run-container.yml.j2
+++ b/src/cnc/flavors/gcp/shared/deploy/run-container.yml.j2
@@ -42,6 +42,8 @@ spec:
         {% endif %}
       {% endif %}
         env:
+        - name: CNC_DEPLOY_TIMESTAMP
+          value: {{ deployer.current_timestamp }}
         - name: CNC_PROVISIONED
           value: "1"
         {% for variable in service.insecure_environment_items %}

--- a/src/cnc/models/cycle_stage_base.py
+++ b/src/cnc/models/cycle_stage_base.py
@@ -5,6 +5,7 @@ import shutil
 from pathlib import Path
 from functools import partial, cached_property
 import shlex
+from datetime import datetime
 
 from jinja2 import (
     Environment,
@@ -38,6 +39,10 @@ class _TemplatedBase:
     @property
     def custom_template_dir(self):
         return f"{self.config_files_path}/custom"
+
+    @property
+    def current_timestamp(self):
+        return datetime.now().isoformat()
 
     def setup(self):
         if not os.path.isdir(self.config_files_path):


### PR DESCRIPTION
cloud run does not deploy a new revision of a service if the configuration has not changed
this prevents you from redeploying if, for example, you've only changed the value of some secrets