### PR TITLE
docs: correct service name param in `toolbox` command examples

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -119,11 +119,11 @@ Manage development toolboxes for environments.
 #### Subcommands:
 - `start`: Start a toolbox session
   ```
-  cnc toolbox start <environment_name> [--service <name>] [--tag <tag>] [--proxy-only]
+  cnc toolbox start <environment_name> [--service-name <name>] [--tag <tag>] [--proxy-only]
   ```
 - `run`: Run a command in a toolbox
   ```
-  cnc toolbox run <environment_name> [--service <name>] [--tag <tag>] -- <command>...
+  cnc toolbox run <environment_name> [--service-name <name>] [--tag <tag>] -- <command>...
   ```
 
 ### inspector

--- a/docs/toolboxes.md
+++ b/docs/toolboxes.md
@@ -20,13 +20,13 @@ This makes it easy to perform tasks like running database migrations, starting a
 To start an interactive toolbox session:
 
 ```bash
-cnc toolbox start <environment-name> [--service <service-name>]
+cnc toolbox start <environment-name> [--service-name <service-name>]
 ```
 
 For example:
 
 ```bash
-cnc toolbox start dev --service backend
+cnc toolbox start dev --service-name backend
 ```
 
 This will start an interactive shell in the container for the `backend` service in the `dev` environment.
@@ -36,13 +36,13 @@ This will start an interactive shell in the container for the `backend` service 
 To run a specific command in a toolbox:
 
 ```bash
-cnc toolbox run <environment-name> [--service <service-name>] -- <command>
+cnc toolbox run <environment-name> [--service-name <service-name>] -- <command>
 ```
 
 For example:
 
 ```bash
-cnc toolbox run dev --service backend -- python manage.py migrate
+cnc toolbox run dev --service-name backend -- python manage.py migrate
 ```
 
 This will run the Django migration command in the `backend` service of the `dev` environment.
@@ -52,7 +52,7 @@ This will run the Django migration command in the `backend` service of the `dev`
 If you only need to set up port forwarding to cloud resources without starting a container:
 
 ```bash
-cnc toolbox start <environment-name> --service <service-name> --proxy-only
+cnc toolbox start <environment-name> --service-name <service-name> --proxy-only
 ```
 
 This is useful when you want to connect to cloud resources from your local machine using local tools.


### PR DESCRIPTION
The `cnc toobox` commands accepts the service name for which to build a toolbox as `--service-name`, not `--service`